### PR TITLE
Add preprocessing CLI

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -1,0 +1,110 @@
+"""Command line interface for preprocessing datasets."""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Make src modules importable when running from repository root
+sys.path.append(str(Path(__file__).resolve().parents[1] / "workspace"))
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Preprocess raw data and generate train/val/test splits",
+    )
+    parser.add_argument(
+        "--input-dir",
+        required=True,
+        help="Directory containing raw datasets",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to save processed parquet files",
+    )
+    parser.add_argument(
+        "--train-size",
+        type=float,
+        default=0.7,
+        help="Proportion of authors in the training split",
+    )
+    parser.add_argument(
+        "--val-size",
+        type=float,
+        default=0.15,
+        help="Proportion of authors in the validation split",
+    )
+    parser.add_argument(
+        "--test-size",
+        type=float,
+        default=0.15,
+        help="Proportion of authors in the test split",
+    )
+    parser.add_argument(
+        "--random-seed",
+        type=int,
+        default=42,
+        help="Random seed for splitting",
+    )
+    parser.add_argument(
+        "--max-tweets-per-source",
+        type=int,
+        default=None,
+        help="Limit tweets loaded per source dataset",
+    )
+    parser.add_argument(
+        "--max-tweets-per-author",
+        type=int,
+        default=None,
+        help="Limit tweets kept per author",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="",
+        help="Optional prefix for output filenames",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    # Heavy imports happen after argument parsing so `--help` works without
+    # requiring optional dependencies like PyTorch.
+    from src.data_tools.preprocessor import load_and_clean_data
+    from src.data_tools.dataset import create_data_splits
+
+    df = load_and_clean_data(
+        args.input_dir,
+        max_tweets_per_source=args.max_tweets_per_source,
+        max_tweets_per_author=args.max_tweets_per_author,
+    )
+
+    df = df.rename(columns={"account": "author", "tweet": "text"})
+
+    train_df, val_df, test_df = create_data_splits(
+        df,
+        train_size=args.train_size,
+        val_size=args.val_size,
+        test_size=args.test_size,
+        random_state=args.random_seed,
+    )
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    prefix = f"{args.prefix}_" if args.prefix else ""
+    for name, split_df in {
+        "train": train_df,
+        "val": val_df,
+        "test": test_df,
+    }.items():
+        path = out_dir / f"{prefix}{name}.parquet"
+        split_df.to_parquet(path, index=False)
+        print(f"Saved {name} split to {path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -103,3 +103,21 @@ config = {
 ## Acknowledgments
 - Hugging Face Transformers
 - PyTorch community
+
+## Preprocessing Script
+Use `scripts/preprocess.py` to prepare the dataset outside of the notebooks.
+The script loads raw files, creates author-based splits and saves each split as
+parquet files.
+
+```bash
+python scripts/preprocess.py \
+    --input-dir /path/to/raw/data \
+    --output-dir /path/to/output \
+    --random-seed 42
+```
+
+This command generates `train.parquet`, `val.parquet` and `test.parquet` in the
+output directory. Additional arguments like `--train-size`, `--val-size`, and
+`--test-size` control the split ratios, while `--max-tweets-per-source` and
+`--max-tweets-per-author` limit dataset size. Run the script with `--help` for a
+full list of options.


### PR DESCRIPTION
## Summary
- add command line preprocessing script to create dataset splits
- document script usage in README
- move heavy imports inside `main` so `--help` works without extra deps

## Testing
- `python -m py_compile scripts/preprocess.py`
- `python scripts/preprocess.py --help`
